### PR TITLE
CSV upload for subscribe / unsubscribe on backend

### DIFF
--- a/src/components/CSVUpload/CSVUpload.tsx
+++ b/src/components/CSVUpload/CSVUpload.tsx
@@ -11,6 +11,7 @@ interface CSVUploadProps {
   fileInfo: { name: string; count: number }[];
   onMetadataChange: (files: { name: string; count: number }[]) => void;
   showTitle?: boolean;
+  onFileUpload: (file: File) => void;
 }
 export const CSV_UPLOAD_ROW_TITLE = 'tokenId';
 
@@ -20,12 +21,17 @@ export const CSVUpload: React.FC<CSVUploadProps> = ({
   fileInfo,
   onMetadataChange,
   showTitle = true,
+  onFileUpload,
 }) => {
   const [error, setError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const { setNotification } = useContext(NotificationContext);
 
   const handleFile = (file: File) => {
+    if (fileInfo.length > 0) {
+      return setNotification('Only one file can be uploaded at a time', '', 'error');
+    }
+
     if (fileInfo.some((f) => f.name === file.name)) {
       return setNotification('Duplicate file upload', '', 'error');
     }
@@ -65,6 +71,7 @@ export const CSVUpload: React.FC<CSVUploadProps> = ({
         setError(null);
         onMetadataChange([...fileInfo, { name: file.name, count: ids.length }]);
         onChange([...vehicleTokenIds, ...ids]);
+        onFileUpload(file);
       },
       error: () => setError('Failed to parse CSV.'),
     });

--- a/src/components/Webhooks/create/SubscribeVehicles/SubscribeVehicles.tsx
+++ b/src/components/Webhooks/create/SubscribeVehicles/SubscribeVehicles.tsx
@@ -7,8 +7,9 @@ import { CSVUpload } from '@/components/CSVUpload';
 import { useState } from 'react';
 
 export const WebhookSubscribeVehiclesStep = () => {
-  const { control, watch } = useFormContext<WebhookFormInput>();
+  const { control, watch, setValue } = useFormContext<WebhookFormInput>();
   const allVehicles = watch('subscribe.allVehicles');
+  const [vehicleTokenIds, setVehicleTokenIds] = useState<string[]>([]);
   const [fileInfo, setFileInfo] = useState<{ name: string; count: number }[]>([]);
 
   return (
@@ -30,18 +31,14 @@ export const WebhookSubscribeVehiclesStep = () => {
       {!allVehicles && (
         <Section>
           <div>
-            <Controller
-              name="subscribe.vehicleTokenIds"
-              control={control}
-              defaultValue={[]}
-              render={({ field: { onChange, value } }) => (
-                <CSVUpload
-                  vehicleTokenIds={Array.isArray(value) ? value : []}
-                  onChange={onChange}
-                  fileInfo={fileInfo}
-                  onMetadataChange={setFileInfo}
-                />
-              )}
+            <CSVUpload
+              vehicleTokenIds={vehicleTokenIds}
+              onChange={setVehicleTokenIds}
+              fileInfo={fileInfo}
+              onMetadataChange={setFileInfo}
+              onFileUpload={(file) => {
+                setValue('subscribe.file', file);
+              }}
             />
           </div>
         </Section>

--- a/src/components/Webhooks/edit/UnsubscribeVehiclesModal.tsx
+++ b/src/components/Webhooks/edit/UnsubscribeVehiclesModal.tsx
@@ -15,7 +15,7 @@ export const UnsubscribeVehiclesModal: FC<SubscribeVehiclesActionModalProps> = (
   clientId,
   onSuccess,
 }) => {
-  const [file, setFile] = useState<File | null>(null);
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [vehicleTokenIds, setVehicleTokenIds] = useState<string[]>([]);
   const [fileInfo, setFileInfo] = useState<{ name: string; count: number }[]>([]);
   const [loading, setLoading] = useState(false);
@@ -23,11 +23,11 @@ export const UnsubscribeVehiclesModal: FC<SubscribeVehiclesActionModalProps> = (
   const { setNotification } = useContext(NotificationContext);
 
   const handleSubmit = async () => {
-    if (!file) return;
+    if (!uploadedFile) return;
     try {
       setLoading(true);
       const formData = new FormData();
-      formData.append('file', file);
+      formData.append('file', uploadedFile);
       const response = await unsubscribeByCsv({
         webhookId,
         formData,
@@ -40,7 +40,7 @@ export const UnsubscribeVehiclesModal: FC<SubscribeVehiclesActionModalProps> = (
       );
       onSuccess?.();
       setIsOpen(false);
-      setFile(null);
+      setUploadedFile(null);
       setVehicleTokenIds([]);
       setFileInfo([]);
     } catch (err) {
@@ -61,11 +61,11 @@ export const UnsubscribeVehiclesModal: FC<SubscribeVehiclesActionModalProps> = (
           fileInfo={fileInfo}
           onMetadataChange={setFileInfo}
           showTitle={false}
-          onFileUpload={setFile}
+          onFileUpload={setUploadedFile}
         />
       </div>
       <div className="flex flex-col w-full gap-4 pt-4">
-        <Button onClick={handleSubmit} disabled={!file || loading}>
+        <Button onClick={handleSubmit} disabled={!uploadedFile || loading}>
           {loading ? 'Unsubscribing...' : 'Unsubscribe'}
         </Button>
         <Button onClick={() => setIsOpen(false)} className="dark">

--- a/src/services/webhook.ts
+++ b/src/services/webhook.ts
@@ -192,34 +192,6 @@ export const unsubscribeAllVehicles = async ({
   }
 };
 
-export const subscribeVehicleIds = async (
-  webhookId: string,
-  tokenIds: string[],
-  token: string,
-) => {
-  const results = await Promise.allSettled(
-    tokenIds.map((tokenId) =>
-      subscribeVehicle({ webhookId, vehicleTokenId: tokenId, token }),
-    ),
-  );
-  const failures = results.filter((r) => r.status === 'rejected');
-  return failures.length;
-};
-
-export const unsubscribeVehicleIds = async (
-  webhookId: string,
-  tokenIds: string[],
-  token: string,
-) => {
-  const results = await Promise.allSettled(
-    tokenIds.map((tokenId) =>
-      unsubscribeVehicle({ webhookId, vehicleTokenId: tokenId, token }),
-    ),
-  );
-  const failures = results.filter((r) => r.status === 'rejected');
-  return failures.length;
-};
-
 export const subscribeByCsv = async ({
   webhookId,
   token,
@@ -243,5 +215,28 @@ export const subscribeByCsv = async ({
     return data;
   } catch (err) {
     throw new Error(extractAxiosMessage(err, 'Unknown error subscribing by CSV'));
+  }
+};
+
+export const unsubscribeByCsv = async ({
+  webhookId,
+  token,
+  formData,
+}: {
+  webhookId: string;
+  token: string;
+  formData: FormData;
+}) => {
+  try {
+    const client = getWebhooksApiClient(token);
+    const { data } = await client.delete(`/v1/webhooks/${webhookId}/unsubscribe/csv`, {
+      data: formData,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    return data;
+  } catch (err) {
+    throw new Error(extractAxiosMessage(err, 'Unknown error unsubscribing by CSV'));
   }
 };

--- a/src/services/webhook.ts
+++ b/src/services/webhook.ts
@@ -219,3 +219,29 @@ export const unsubscribeVehicleIds = async (
   const failures = results.filter((r) => r.status === 'rejected');
   return failures.length;
 };
+
+export const subscribeByCsv = async ({
+  webhookId,
+  token,
+  formData,
+}: {
+  webhookId: string;
+  token: string;
+  formData: FormData;
+}) => {
+  try {
+    const client = getWebhooksApiClient(token);
+    const { data } = await client.post(
+      `/v1/webhooks/${webhookId}/subscribe/csv`,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    );
+    return data;
+  } catch (err) {
+    throw new Error(extractAxiosMessage(err, 'Unknown error subscribing by CSV'));
+  }
+};

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -38,7 +38,7 @@ export interface WebhookFormInput {
   };
   subscribe?: {
     allVehicles?: boolean;
-    vehicleTokenIds?: string[];
+    file?: File;
   };
 }
 


### PR DESCRIPTION
Uses new endpoints to upload CSVs for bulk subscribe / unsubscribe instead of manually parsing and submitting API calls.
- Don't merge until https://github.com/DIMO-Network/vehicle-events-api/tree/feature/upload-csv-to-subscribe is merged