### PR TITLE
ACC-560: Enable api status in nav

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -68,9 +68,9 @@ export const mainMenu = [
     label: 'API Status',
     icon: MonitorHeartIcon,
     iconClassName: 'h-5 w-5',
-    link: '/api-status',
-    external: false,
-    disabled: true,
+    link: 'https://status.dimo.co/',
+    external: true,
+    disabled: false,
   },
 ];
 


### PR DESCRIPTION
Enables the API Status in the sidebar, links to `https://status.dimo.co/`
My first lil PR on console hopefully i didnt break everything 🥹