### PR TITLE
[chore] update documentation link

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -66,7 +66,7 @@ const baseMainMenu = [
     label: 'Documentation',
     icon: SummarizeIcon,
     iconClassName: 'h-5 w-5',
-    link: 'https://docs.dimo.zone/developer-platform',
+    link: 'https://dimo.org/docs',
     external: true,
     disabled: false,
   },


### PR DESCRIPTION
This pull request updates the documentation link in the main navigation menu to point to the new documentation site.

- Navigation update:
  * Changed the `Documentation` menu item's link in `src/config/navigation.ts` from `https://docs.dimo.zone/developer-platform` to `https://dimo.org/docs`.